### PR TITLE
Basic python3 compatibility

### DIFF
--- a/MakerBot/MakerBotPkgFinder.py
+++ b/MakerBot/MakerBotPkgFinder.py
@@ -16,12 +16,12 @@
 """See docstring for MakerBotPkgFinder class"""
 
 from __future__ import absolute_import
-import os
+
 import glob
+import os
 
-from autopkglib.DmgMounter import DmgMounter
 from autopkglib import ProcessorError
-
+from autopkglib.DmgMounter import DmgMounter
 
 __all__ = ["MakerBotPkgFinder"]
 

--- a/MakerBot/MakerBotPkgFinder.py
+++ b/MakerBot/MakerBotPkgFinder.py
@@ -15,6 +15,7 @@
 # limitations under the License.
 """See docstring for MakerBotPkgFinder class"""
 
+from __future__ import absolute_import
 import os
 import glob
 

--- a/MakerBot/MakerBotPkgFinder.py
+++ b/MakerBot/MakerBotPkgFinder.py
@@ -60,7 +60,7 @@ class MakerBotPkgFinder(DmgMounter):
         try:
             self.env["makerbot_pkg"] = self.find_match(mount_point, CORE)
             self.output("Found %s" % self.env["makerbot_pkg"])
-        except BaseException as err:
+        except Exception as err:
             raise ProcessorError(err)
         finally:
             self.unmount(self.env["dmg_path"])

--- a/MakerBot/MakerBotURLProvider.py
+++ b/MakerBot/MakerBotURLProvider.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 #
+from __future__ import absolute_import
 import re
 import urllib
 import urllib2

--- a/MakerBot/MakerBotURLProvider.py
+++ b/MakerBot/MakerBotURLProvider.py
@@ -1,13 +1,17 @@
 #!/usr/bin/env python
 #
 from __future__ import absolute_import
+
 import re
-import urllib
 import urllib2
 import urlparse
 
 from autopkglib import Processor, ProcessorError
 
+try:
+    from urllib import request as urllib  # For Python 3
+except ImportError:
+    import urllib  # For Python 2
 
 __all__ = ["MakerBotURLProvider"]
 
@@ -54,7 +58,7 @@ class MakerBotURLProvider(Processor):
         url = url_bits.scheme + "://" + url_bits.netloc + encoded_path
         if not m:
           raise ProcessorError(
-              "error Couldn't find %s download URL in %s" 
+              "error Couldn't find %s download URL in %s"
               % (base_url))
 
         return url
@@ -68,5 +72,3 @@ class MakerBotURLProvider(Processor):
 if __name__ == "__main__":
   processor = MakerBotURLProvider()
   processor.execute_shell()
-
-

--- a/MakerBot/MakerBotURLProvider.py
+++ b/MakerBot/MakerBotURLProvider.py
@@ -46,7 +46,7 @@ class MakerBotURLProvider(Processor):
           f = urllib2.urlopen(req)
           html = f.read()
           f.close()
-        except BaseException as e:
+        except Exception as e:
           raise ProcessorError("Can't download %s: %s" % (base_url, e))
 
         # Search for download link.


### PR DESCRIPTION
In order to make your processors more compatible with AutoPkg running in Python 3, I've applied a few adjustments suggested by `python-modernize`, `pylint --py3k`, and `pylint` in general.

More adjustments may need to be made manually later (including `urllib2` and `urlparse`), but this should catch the low-hanging fruit right now.